### PR TITLE
Added Date for paid comissions and revoked

### DIFF
--- a/includes/short-codes.php
+++ b/includes/short-codes.php
@@ -155,6 +155,7 @@ function eddc_user_commissions( $user_id = 0 ) {
 								<th class="edd_commission_item"><?php _e('Item', 'eddc'); ?></th>
 								<th class="edd_commission_amount"><?php _e('Amount', 'eddc'); ?></th>
 								<th class="edd_commission_rate"><?php _e('Rate', 'eddc'); ?></th>
+								<th class="edd_commission_date"><?php _e('Date', 'eddc'); ?></th>
 								<?php do_action( 'eddc_user_commissions_paid_head_row_end' ); ?>
 							</tr>
 						</thead>
@@ -212,6 +213,7 @@ function eddc_user_commissions( $user_id = 0 ) {
 								<th class="edd_commission_item"><?php _e('Item', 'eddc'); ?></th>
 								<th class="edd_commission_amount"><?php _e('Amount', 'eddc'); ?></th>
 								<th class="edd_commission_rate"><?php _e('Rate', 'eddc'); ?></th>
+								<th class="edd_commission_date"><?php _e('Date', 'eddc'); ?></th>
 								<?php do_action( 'eddc_user_commissions_revoked_head_row_end' ); ?>
 							</tr>
 						</thead>


### PR DESCRIPTION
It seems the date text was missing for paid and revoked commissions.  It shows the numerical date but  did not show 'date' above it like it does for unpaid commissions.