### PR TITLE
Harden sanitization on commission rates

### DIFF
--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -96,16 +96,39 @@ function eddc_download_meta_box_save( $post_id ) {
 
 		update_post_meta( $post_id, '_edd_commisions_enabled', true );
 
-		$new = isset( $_POST['edd_commission_settings'] ) ? $_POST['edd_commission_settings'] : false;
+		$new  = isset( $_POST['edd_commission_settings'] ) ? $_POST['edd_commission_settings'] : false;
+		$type = ! empty( $_POST['edd_commission_settings']['type'] ) ? $_POST['edd_commission_settings']['type'] : 'percentage';
+
 		if ( $new ) {
 			if( ! empty( $new['amount'] ) ) {
 				$new['amount'] = str_replace( '%', '', $new['amount'] );
 				$new['amount'] = str_replace( '$', '', $new['amount'] );
 
-				if ( $new['amount'] < 1 && 'percentage' === $_POST['edd_commission_settings']['type'] ) {
-					$new['amount'] = $new['amount'] * 100;
+				$values           = explode( ',', $new['amount'] );
+				$sanitized_values = array();
+
+				foreach ( $values as $key => $value ) {
+
+					switch( $type ) {
+						case 'flat':
+							$value = $value < 0 || ! is_numeric( $value ) ? 0 : $value;
+							break;
+						case 'percentage':
+						default:
+							if ( $value < 0 || ! is_numeric( $value ) ) {
+								$value = 0;
+							}
+
+							$value = $value < 1 ? $value * 100 : $value;
+							break;
+					}
+
+					$sanitized_values[ $key ] = round( $value, 2 );
+
 				}
-				$new['amount'] = trim( $new['amount'] );
+
+				$new_values    = implode( ',', $sanitized_values );
+				$new['amount'] = trim( $new_values );
 			}
 		}
 		update_post_meta( $post_id, '_edd_commission_settings', $new );

--- a/includes/commission-functions.php
+++ b/includes/commission-functions.php
@@ -124,7 +124,7 @@ function eddc_record_commission( $payment_id, $new_status, $old_status ) {
 								if( 'include_shipping' == $shipping ) {
 
 									$commission_amount += $fee['amount'];
-									
+
 								}
 
 							}
@@ -261,8 +261,10 @@ function eddc_get_recipient_rate( $download_id = 0, $user_id = 0 ) {
 
 	}
 
+	$rate = (float) $rate;
+
 	// Check for a user specific global rate
-	if( empty( $download_id ) || empty( $rate ) ) {
+	if( empty( $download_id ) || ( empty( $rate ) && 0 !== $rate ) ) {
 
 		$rate = get_user_meta( $user_id, 'eddc_user_rate', true );
 
@@ -273,7 +275,7 @@ function eddc_get_recipient_rate( $download_id = 0, $user_id = 0 ) {
 	}
 
 	// Check for an overall global rate
-	if( empty( $rate ) && eddc_get_default_rate() ) {
+	if( empty( $rate ) && 0 !== $rate && eddc_get_default_rate() ) {
 		$rate = eddc_get_default_rate();
 	}
 
@@ -748,9 +750,9 @@ function eddc_generate_payout_file( $data ) {
 add_action( 'edd_generate_payouts', 'eddc_generate_payout_file' );
 
 function eddc_generate_user_export_file( $data ) {
-	
+
 	$user_id = ! empty( $data['user_id'] ) ? intval( $data['user_id'] ) : get_current_user_id();
-	
+
 	if ( ( empty( $user_id ) || ! eddc_user_has_commissions( $user_id ) ) ) {
 		return;
 	}


### PR DESCRIPTION
#105 This checks the commission rates on saving, and does some hardening on them to make sure they meet some cases of being 0 or greater, limits them to 2 decimal places, and makes sure that `0` is an allowed rate to save.