### PR TITLE
Improper Download Price Option name #96

### DIFF
--- a/includes/EDD_C_List_Table.php
+++ b/includes/EDD_C_List_Table.php
@@ -39,7 +39,7 @@ class EDD_C_List_Table extends WP_List_Table {
 		switch ( $column_name ) {
 			case 'rate':
 				$download = get_post_meta( $item['ID'], '_download_id', true );
-				$type = eddc_get_commission_type( $download );
+				$type     = eddc_get_commission_type( $download );
 				if( 'percentage' == $type )
 					return $item[ $column_name ] . '%';
 				else
@@ -80,12 +80,16 @@ class EDD_C_List_Table extends WP_List_Table {
 
 		$user = get_userdata( $item['user'] );
 
-		//Return the title contents
-		return sprintf( '%1$s <span style="color:silver">(id:%2$s)</span>%3$s',
-			/*$1%s*/ '<a href="' . esc_url( add_query_arg( 'user', $user->ID ) ) . '" title="' . __( 'View all commissions for this user', 'eddc' ) . '"">' . $user->display_name . '</a>',
-			/*$2%s*/ $item['ID'],
-			/*$3%s*/ $this->row_actions( $actions )
-		);
+		if ( false !== $user ) {
+			//Return the title contents
+			return sprintf( '%1$s <span style="color:silver">(id:%2$s)</span>%3$s',
+				/*$1%s*/ '<a href="' . esc_url( add_query_arg( 'user', $user->ID ) ) . '" title="' . __( 'View all commissions for this user', 'eddc' ) . '"">' . $user->display_name . '</a>',
+				/*$2%s*/ $item['ID'],
+				/*$3%s*/ $this->row_actions( $actions )
+			);
+		} else {
+			return '<em>' . __( 'Invalid User', 'eddc' ) . '</em>';
+		}
 	}
 
 	function column_cb( $item ) {
@@ -334,7 +338,12 @@ class EDD_C_List_Table extends WP_List_Table {
 				$commission_id   = get_the_ID();
 				$commission_info = get_post_meta( $commission_id, '_edd_commission_info', true );
 				$download_id     = get_post_meta( $commission_id, '_download_id', true );
-				$variation       = get_post_meta( $commission_id, '_edd_commission_download_variation', true );
+
+				$variation = '';
+				$has_variable_prices = edd_has_variable_prices( $download_id );
+				if ( $has_variable_prices ) {
+					$variation = get_post_meta( $commission_id, '_edd_commission_download_variation', true );
+				}
 
 				$commissions_data[] = array(
 					'ID'        => $commission_id,

--- a/includes/commission-functions.php
+++ b/includes/commission-functions.php
@@ -89,7 +89,9 @@ function eddc_record_commission( $payment_id, $new_status, $old_status ) {
 				$type = eddc_get_commission_type( $download_id );
 
 				// but if we have price variations, then we need to get the name of the variation
-				if ( edd_has_variable_prices( $download_id ) ) {
+				$has_variable_prices = edd_has_variable_prices( $download_id );
+
+				if ( $has_variable_prices ) {
 					$price_id  = edd_get_cart_item_price_id ( $download );
 					$variation = edd_get_price_option_name( $download_id, $price_id );
 				}
@@ -156,7 +158,7 @@ function eddc_record_commission( $payment_id, $new_status, $old_status ) {
 					update_post_meta( $commission_id, '_edd_commission_payment_id', $payment_id );
 
 					// If we are dealing with a variation, then save variation info
-					if ( isset( $variation ) ) {
+					if ( $has_variable_prices && isset( $variation ) ) {
 						update_post_meta( $commission_id, '_edd_commission_download_variation', $variation );
 					}
 


### PR DESCRIPTION
This fixes a bug noted #96 where the creation of recorded commissions when a variable price is added to the cart first, and then a single price, the variable Price ID name was added to the single price post meta.

It prevents this recording from happening here on out, and fixes old data by making sure the commission download has variable prices before showing the price opiton name in the list table.

Also prevents commissions for deleted users from throwing a ntoice on the list table.