### PR TITLE
Make Shipping options more understandable

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -67,9 +67,9 @@ function eddc_settings_extensions( $settings ) {
 			'desc'    => __( 'How should shipping fees affect commission calculations?', 'eddc' ),
 			'type'    => 'select',
 			'options' => array(
-				'ignored'          => __( 'Ignore shipping fees', 'eddc' ),
-				'include_shipping' => __( 'Shipping fee paid to recipient', 'eddc' ),
-				'exclude_shipping' => __( 'Shipping fee not paid to recipient', 'eddc' ),
+				'ignored'          => __( 'Split shipping fees equally.', 'eddc' ),
+				'include_shipping' => __( 'Shipping fee paid to first user ID in product\'s Commission settings.', 'eddc' ),
+				'exclude_shipping' => __( 'Shipping fee paid to Store.', 'eddc' ),
 			),
 		);
 	}


### PR DESCRIPTION
Make the shipping settings for Commissions more easy to understand based on their functions. This changes

```
Ignore shipping fees
Shipping fee paid to recipient
Shipping fee not paid to recipient
```
to

```
Split shipping fee equally
Shipping fee paid to first user ID in product's Commission settings
Shipping fee paid to Store
```