### PR TITLE
Allow users to individually disable sale email notifications

### DIFF
--- a/includes/email-functions.php
+++ b/includes/email-functions.php
@@ -146,6 +146,10 @@ function eddc_email_alert( $user_id, $commission_amount, $rate, $download_id, $c
 		return;
 	}
 
+	if ( get_user_meta( $user->ID, 'eddc_disable_user_sale_alerts', true ) ) {
+		return;
+	}
+
 	/* send an email alert of the sale */
 	$user    = get_userdata( $user_id );
 	$email   = $user->user_email; // set address here

--- a/includes/user-meta.php
+++ b/includes/user-meta.php
@@ -43,6 +43,14 @@ function eddc_user_paypal_email( $user ) {
 			</td>
 		</tr>
 		<?php endif; ?>
+
+		<tr>
+			<th><label><?php _e('Disable Sale Notification Emails', 'eddc'); ?></label></th>
+			<td>
+				<input name="eddc_disable_user_sale_alerts" type="checkbox" id="eddc_disable_user_sale_alerts" value="1"<?php checked( get_user_meta( $user->ID, 'eddc_disable_user_sale_alerts', true ) ); ?> />
+				<span class="description"><?php _e( 'Check this box if you wish to prevent sale notifications from being sent to this user.', 'easy-digital-downloads' ); ?></span>
+			</td>
+		</tr>
 	</table>
 	<?php
 }
@@ -59,6 +67,12 @@ function eddc_save_user_paypal( $user_id ) {
 		update_user_meta( $user_id, 'eddc_user_paypal', sanitize_text_field( $_POST['eddc_user_paypal'] ) );
 	} else {
 		delete_user_meta( $user_id, 'eddc_user_paypal' );
+	}
+
+	if ( isset( $_POST['eddc_disable_user_sale_alerts'] ) ) {
+		update_user_meta( $user_id, 'eddc_disable_user_sale_alerts', true );
+	} else {
+		delete_user_meta( $user_id, 'eddc_disable_user_sale_alerts' );
 	}
 
 	if ( current_user_can( 'manage_shop_settings' ) ) {


### PR DESCRIPTION
This implements the ability to prevent emails for individual users rather than turning them off globally.